### PR TITLE
Use consistent work dir for editfst, fstcomp, fststat, and pgsm?

### DIFF
--- a/src/rpn-si/editfst/CMakeLists.txt
+++ b/src/rpn-si/editfst/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(editfst
 
 add_dependencies(editfst rmn)
 
-install(TARGETS editfst RUNTIME DESTINATION ${ROOT}/work/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)
+install(TARGETS editfst RUNTIME DESTINATION ${ROOT}/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)

--- a/src/rpn-si/fstcomp/CMakeLists.txt
+++ b/src/rpn-si/fstcomp/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(fstcomp
 
 add_dependencies(fstcomp rmn)
 
-install(TARGETS fstcomp RUNTIME DESTINATION ${ROOT}/work/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)
+install(TARGETS fstcomp RUNTIME DESTINATION ${ROOT}/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)

--- a/src/rpn-si/fststat/CMakeLists.txt
+++ b/src/rpn-si/fststat/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(fststat rmn
 
 add_dependencies(fststat rmn)
 
-install(TARGETS fststat RUNTIME DESTINATION ${ROOT}/work/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)
+install(TARGETS fststat RUNTIME DESTINATION ${ROOT}/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)

--- a/src/rpn-si/pgsm/CMakeLists.txt
+++ b/src/rpn-si/pgsm/CMakeLists.txt
@@ -10,4 +10,4 @@ target_link_libraries(pgsm
 
 add_dependencies(pgsm rmn)
 
-install(TARGETS pgsm RUNTIME DESTINATION ${ROOT}/work/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)
+install(TARGETS pgsm RUNTIME DESTINATION ${ROOT}/work-${OS}-${COMPILER}-${COMP_VERSION}/bin)


### PR DESCRIPTION
There's an extra `/work` subdirectory for those four targets.  Doesn't seem to matter for default `cmake ../project` command-line invocation.  However, when invoking from the Python skbuild package I was getting the following error:
```
  Traceback (most recent call last):
  
    CMake-installed files must be within the project root.
      Project Root:
        /tmp/pip-req-build-0_uzo1w6/gem/work-Ubuntu-18.04-x86_64-gnu-7.5.0
      Violating Files:
        /tmp/pip-req-build-0_uzo1w6/gem/work/work-Ubuntu-18.04-x86_64-gnu-7.5.0/bin/fststat
        /tmp/pip-req-build-0_uzo1w6/gem/work/work-Ubuntu-18.04-x86_64-gnu-7.5.0/bin/fstcomp
        /tmp/pip-req-build-0_uzo1w6/gem/work/work-Ubuntu-18.04-x86_64-gnu-7.5.0/bin/pgsm
        /tmp/pip-req-build-0_uzo1w6/gem/work/work-Ubuntu-18.04-x86_64-gnu-7.5.0/bin/editfst
```